### PR TITLE
Enable keyboard shortcuts for comment lines.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Abaqus Sublime Package
 Tool set for faster Abaqus keywords editing with Sublime Text 3
+
+This is a fork of the original work by [SenhorLucas](https://github.com/SenhorLucas/AbaqusSublimePackage). The following changes have been made:
+1. Added a Comment metadata file so that the standard keyboard shortcuts for line comments (Ctl+/) and block comments (Ctl+Shft+/) can be used to automatically comment/uncomment selected lines.
+
 ## Syntax Highlight
 ![syntax_highlight.gif](https://raw.githubusercontent.com/SenhorLucas/AbaqusSublimePackage/master/images/syntax_highlight.gif)
 ## Plugins

--- a/settings/Comments (abaqus).tmPreferences
+++ b/settings/Comments (abaqus).tmPreferences
@@ -2,7 +2,7 @@
 <!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-    <key>name</key><string>Comments</string>
+    <key>name</key><string>Comments for AbaqusSublimePackage by ropeonfire ("https://github.com/ropeonfire")</string>
     <key>scope</key><string>source.abaqus</string>
     <key>settings</key>
     <dict>

--- a/settings/Comments (abaqus).tmPreferences
+++ b/settings/Comments (abaqus).tmPreferences
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>name</key><string>Comments</string>
+    <key>scope</key><string>source.abaqus</string>
+    <key>settings</key>
+    <dict>
+        <key>shellVariables</key>
+        <array>
+            <dict>
+                <key>name</key>
+                <string>TM_COMMENT_START</string>
+                <key>value</key>
+                <string>** </string>
+            </dict>
+            <dict>
+                <key>name</key>
+                <string>TM_COMMENT_DISABLE_INDENT</string>
+                <key>value</key>
+                <string>yes</string>
+            </dict>
+        </array>
+    </dict>
+</dict>
+</plist>


### PR DESCRIPTION
I created a new Comments metadata file so that the standard keyboard shortcuts to toggle line comments (Ctrl+/) and block comments (Ctrl+Shft+/) now work with Abaqus language files. At the beginning of each selected line, two asterisks (**) will be inserted. 